### PR TITLE
report basic statistics about a scan as metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,6 @@ deploy:
 define deploy
 	$(eval URL:=$(KO_DOCKER_REPO)/cert-scanner-darkly)
 	{ kubectl create namespace ${NAMESPACE} || true ;}
-	helm upgrade --install -n ${NAMESPACE} $(CHART) charts/$(CHART) --values charts/cert-scanner/values.yaml --set image.url=$(URL) --set image.tag=$(VERSION)
+	helm upgrade --install -n ${NAMESPACE} $(CHART) charts/$(CHART) --values charts/cert-scanner/values.yaml --set image.url=$(URL) --set image.tag=$(VERSION) --set image.pullPolicy=Never
 	kubectl rollout restart deployment -n ${NAMESPACE} $(CHART)
 endef

--- a/cert-scanner/config/config.go
+++ b/cert-scanner/config/config.go
@@ -30,6 +30,7 @@ const (
 	ReportersMetricsTLSVersion       = "reporters.metrics.tls_version"
 	ReportersMetricsTrustChain       = "reporters.metrics.expiry"
 	ReportersLoggingEnabled          = "reporters.logging.enabled"
+	ReportersScanStatsOnlySuccessful = "reporters.scan_stats.only_successful"
 	ReportersMetricsEnabled          = "metrics.enabled"
 	Interval                         = "scan.interval"
 	Timeout                          = "scan.timeout"

--- a/cert-scanner/reporters/metrics/scan_stats.go
+++ b/cert-scanner/reporters/metrics/scan_stats.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sgargan/cert-scanner-darkly/config"
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"github.com/sgargan/cert-scanner-darkly/utils"
+	"github.com/spf13/viper"
+)
+
+var (
+	TLSVersionCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "cert_scanner",
+		Name:      "tls_version_total",
+		Help:      "counts of each tls version detected",
+	}, []string{
+		"source",
+		"source_type",
+		"name",
+		"success",
+		"version",
+		"cypher",
+	})
+
+	ScanDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "cert_scanner",
+		Name:      "scan_duration_milliseconds",
+		Help:      "duration of scans in milliseconds",
+		Buckets:   []float64{5, 10, 50, 75, 100, 250, 500, 750, 1000, 1500},
+	}, []string{
+		"source",
+		"source_type",
+		"success",
+	})
+)
+
+// ScanStatsReporter tracks metrics about each scan,
+type ScanStatsReporter struct {
+	tlsVersionCounter     CounterVec
+	scanDurationHistogram HistogramVec
+}
+
+func (r *ScanStatsReporter) Report(ctx context.Context, scan *TargetScan) {
+	for _, scanResult := range scan.Results {
+		source := scan.Target.Source
+		sourceType := scan.Target.SourceType
+		name := scan.Target.Name
+		version := "n/a"
+		cypher := "n/a"
+		success := "false"
+
+		if !scanResult.Failed {
+			success = "true"
+		}
+
+		if scanResult.State != nil {
+			version = utils.ToVersion(int(scanResult.State.Version))
+			cypher = scanResult.Cipher.Name
+		}
+
+		r.scanDurationHistogram.WithLabelValues(source, sourceType, success).Observe(float64(scan.Duration.Milliseconds()))
+
+		onlySuccessful := viper.GetBool(config.ReportersScanStatsOnlySuccessful)
+		if (onlySuccessful && !scanResult.Failed) || !onlySuccessful {
+			r.tlsVersionCounter.WithLabelValues(source, sourceType, name, success, version, cypher).Inc()
+		}
+	}
+}
+
+func CreateScanStatsReporter() (Reporter, error) {
+	return &ScanStatsReporter{
+		TLSVersionCounter,
+		ScanDurationHistogram,
+	}, nil
+}

--- a/cert-scanner/reporters/metrics/scan_stats_test.go
+++ b/cert-scanner/reporters/metrics/scan_stats_test.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sgargan/cert-scanner-darkly/reporters/metrics/mocks"
+	. "github.com/sgargan/cert-scanner-darkly/testutils"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+)
+
+type ScanStatsReporterTests struct {
+	sut          *ScanStatsReporter
+	histogram    *mocks.Histogram
+	histogramVec *mocks.HistogramVec
+	counter      *mocks.Counter
+	counterVec   *mocks.CounterVec
+	suite.Suite
+}
+
+func (t *ScanStatsReporterTests) SetupTest() {
+	t.histogram = &mocks.Histogram{}
+	t.histogramVec = &mocks.HistogramVec{}
+
+	t.counter = &mocks.Counter{}
+	t.counterVec = &mocks.CounterVec{}
+
+	t.sut = &ScanStatsReporter{
+		tlsVersionCounter:     t.counterVec,
+		scanDurationHistogram: t.histogramVec,
+	}
+}
+
+func (t *ScanStatsReporterTests) TestShouldMetricsFromSuccessfulScan() {
+	t.counterVec.On("WithLabelValues", "some-cluster", "kubernetes", "somepod-acdf-bdfe", "true", "1.2", "TLS_AES_128_GCM_SHA256").Return(t.counter)
+	t.counter.On("Inc").Return()
+
+	t.histogramVec.On("WithLabelValues", "some-cluster", "kubernetes", "true").Return(t.histogram)
+	t.histogram.On("Observe", 123.0).Return()
+
+	testScan := CreateTestTargetScan().WithTarget(TestTarget()).Build()
+	testScan.Duration = 123 * time.Millisecond
+	t.sut.Report(context.Background(), testScan)
+
+	t.assertions()
+}
+
+func (t *ScanStatsReporterTests) TestShouldSkipFailedScansIfOnlySuccessfulIsEnabled() {
+	viper.Set("reporters.scan_stats.only_successful", true)
+	defer viper.Reset()
+
+	t.histogramVec.On("WithLabelValues", "some-cluster", "kubernetes", "false").Return(t.histogram)
+	t.histogram.On("Observe", 123.0).Return()
+
+	testScan := CreateTestTargetScan().WithTarget(TestTarget()).Build()
+	testScan.Results[0].Failed = true
+
+	testScan.Duration = 123 * time.Millisecond
+	t.sut.Report(context.Background(), testScan)
+
+	t.assertions()
+}
+
+func (t *ScanStatsReporterTests) assertions() {
+	t.counterVec.AssertExpectations(t.T())
+	t.counter.AssertExpectations(t.T())
+
+	t.histogramVec.AssertExpectations(t.T())
+	t.histogram.AssertExpectations(t.T())
+}
+
+func TestScanStatsReporter(t *testing.T) {
+	suite.Run(t, new(ScanStatsReporterTests))
+}

--- a/cert-scanner/reporters/reporters.go
+++ b/cert-scanner/reporters/reporters.go
@@ -14,6 +14,7 @@ var factories = map[string]Factory[Reporter]{
 	"not_yet_valid": metrics.CreateNotYetValidReporter,
 	"tls_version":   metrics.CreateTLSVersionReporter,
 	"trust_chain":   metrics.CreateTrustChainReporter,
+	"scan_stats":    metrics.CreateScanStatsReporter,
 }
 
 func CreateReporters() (Reporters, error) {

--- a/cert-scanner/testutils/utils.go
+++ b/cert-scanner/testutils/utils.go
@@ -148,6 +148,7 @@ func TestTarget() *Target {
 			Labels:     map[string]string{"foo": "bar", "pod": "somepod-acdf-bdfe"},
 			SourceType: "kubernetes",
 			Source:     "some-cluster",
+			Name:       "somepod-acdf-bdfe",
 		},
 	}
 }

--- a/cert-scanner/utils/tls.go
+++ b/cert-scanner/utils/tls.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+const MaxInt = ^int(0) >> 1
+
+// Convert from a tls version int to a string representation
+func ToVersion(version int) string {
+	switch version {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	}
+	return "unknown"
+}
+
+// Convert from a known version string to a given tls version int
+func FromVersion(version string) (int, error) {
+	switch version {
+	case "1.0":
+		return tls.VersionTLS10, nil
+	case "1.1":
+		return tls.VersionTLS11, nil
+	case "1.2":
+		return tls.VersionTLS12, nil
+	case "1.3":
+		return tls.VersionTLS13, nil
+	}
+	return MaxInt, fmt.Errorf("%s is not a valid tls version string use one of 1.0, 1.1, 1.2, 1.3", version)
+}

--- a/cert-scanner/utils/tls_test.go
+++ b/cert-scanner/utils/tls_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TLSUtilsTests struct {
+	suite.Suite
+}
+
+func (t *TLSUtilsTests) TestConversions() {
+	t.assertVersion("1.3")
+	t.assertVersion("1.2")
+	t.assertVersion("1.1")
+	t.assertVersion("1.0")
+	t.Equal("unknown", ToVersion(1234))
+
+	_, err := FromVersion("not_a_tls_version")
+	t.ErrorContains(err, "not_a_tls_version is not a valid tls version string use one of 1.0, 1.1, 1.2, 1.3")
+
+}
+
+func (t *TLSUtilsTests) assertVersion(version string) {
+	converted, err := FromVersion(version)
+	t.NoError(err)
+	t.Equal(version, ToVersion(converted))
+}
+
+func TestTLSVersionValidations(t *testing.T) {
+	suite.Run(t, &TLSUtilsTests{})
+}

--- a/cert-scanner/validations/tls_version.go
+++ b/cert-scanner/validations/tls_version.go
@@ -1,14 +1,12 @@
 package validations
 
 import (
-	"crypto/tls"
 	"fmt"
 
 	. "github.com/sgargan/cert-scanner-darkly/types"
+	"github.com/sgargan/cert-scanner-darkly/utils"
 	"golang.org/x/exp/slog"
 )
-
-const MaxInt = ^int(0) >> 1
 
 type TLSVersionValidation struct {
 	minVersion int
@@ -37,7 +35,7 @@ func (e *TLSVersionValidationError) Labels() map[string]string {
 }
 
 func CreateTLSVersionValidation(minVersion string) (*TLSVersionValidation, error) {
-	version, err := fromVersion(minVersion)
+	version, err := utils.FromVersion(minVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -50,39 +48,10 @@ func (v *TLSVersionValidation) Validate(scan *TargetScan) ScanError {
 	result := scan.FirstSuccessful
 	if int(result.State.Version) < v.minVersion {
 		return &TLSVersionValidationError{
-			detectedVersion: toVersion(int(result.State.Version)),
-			minVersion:      toVersion(v.minVersion),
+			detectedVersion: utils.ToVersion(int(result.State.Version)),
+			minVersion:      utils.ToVersion(v.minVersion),
 			result:          result,
 		}
 	}
 	return nil
-}
-
-func toVersion(version int) string {
-	switch version {
-	case tls.VersionTLS10:
-		return "1.0"
-	case tls.VersionTLS11:
-		return "1.1"
-	case tls.VersionTLS12:
-		return "1.2"
-	case tls.VersionTLS13:
-		return "1.3"
-	}
-	return "unknown"
-}
-
-// convert from a known string to a given tls version
-func fromVersion(version string) (int, error) {
-	switch version {
-	case "1.0":
-		return tls.VersionTLS10, nil
-	case "1.1":
-		return tls.VersionTLS11, nil
-	case "1.2":
-		return tls.VersionTLS12, nil
-	case "1.3":
-		return tls.VersionTLS13, nil
-	}
-	return MaxInt, fmt.Errorf("%s is not a valid tls version string use one of 1.0, 1.1, 1.2, 1.3", version)
 }

--- a/cert-scanner/validations/tls_version_test.go
+++ b/cert-scanner/validations/tls_version_test.go
@@ -69,24 +69,6 @@ func (t *TLSVersionValidationTests) TestLabels() {
 	}, violation.Labels())
 }
 
-func (t *TLSVersionValidationTests) TestConversions() {
-	t.assertVersion("1.3")
-	t.assertVersion("1.2")
-	t.assertVersion("1.1")
-	t.assertVersion("1.0")
-	t.Equal("unknown", toVersion(1234))
-
-	_, err := fromVersion("not_a_tls_version")
-	t.ErrorContains(err, "not_a_tls_version is not a valid tls version string use one of 1.0, 1.1, 1.2, 1.3")
-
-}
-
-func (t *TLSVersionValidationTests) assertVersion(version string) {
-	converted, err := fromVersion(version)
-	t.NoError(err)
-	t.Equal(version, toVersion(converted))
-}
-
 func TestTLSVersionValidations(t *testing.T) {
 	suite.Run(t, &TLSVersionValidationTests{})
 }

--- a/charts/cert-scanner/values.yaml
+++ b/charts/cert-scanner/values.yaml
@@ -30,14 +30,15 @@ scanConfig:
       min_version: 1.2
     trust_chain:
       use_system_roots: true
-      ca:
-        paths:
-        - /a/ca/path
-        - /b/ca/path
-        - /c/ca/path
+      # ca_paths:
+      #   - /a/ca/path
+      #   - /b/ca/path
+      #   - /c/ca/path
 
   reporters:
     logging:
+      enabled: true
+    scan_stats:
       enabled: true
 
   metrics:


### PR DESCRIPTION
Creates a couple of metrics tracking basic stats about a scan.

The first creates a histogram of the durations taken to scan each target and the second tracks the tls versions detected for each target.

Note that tracking the target name in this metric may be very high cardinality for clusters with large numbers of tls enabled services i.e. mtls enabled service mesh environments.