### PR TITLE
[enhancement] add more tls state validations

### DIFF
--- a/cert-scanner/config/config.go
+++ b/cert-scanner/config/config.go
@@ -22,6 +22,7 @@ const (
 	DiscoveryK8sMatchCIDR            = "discovery.kubernetes.match_cidr"
 	DiscoveryFilePaths               = "discovery.files.paths"
 	ProcessorsTlsEnabled             = "processors.tls-state.enabled"
+	ValidationsCipherSuite           = "validations.cipher_suite.allowed_ciphers"
 	ValidationsExpiryWindow          = "validations.expiry.warning_window"
 	ValidationsTrustChainCACertPaths = "validations.trust_chain.ca_paths"
 	ValidationsTrustChainSystemRoots = "validations.trust_chain.use_system_roots"

--- a/cert-scanner/reporters/metrics/cipher_suite.go
+++ b/cert-scanner/reporters/metrics/cipher_suite.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"github.com/spf13/viper"
+)
+
+var (
+	CipherSuiteLabelKeys = []string{
+		"address", "source", "source_type", "failed", "type", "detected_cipher",
+	}
+
+	InvalidCipherSuiteCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "cert_scanner",
+		Name:      "invalid_cipher_suite_total",
+		Help:      "counts the number of times an invalid cipher suite was detected",
+	}, CipherSuiteLabelKeys)
+)
+
+func CreateCipherSuiteReporter() (Reporter, error) {
+	return &CounterReporter{
+		counter:           InvalidCipherSuiteCounter,
+		ignoreResultTypes: viper.GetStringSlice("validations.cipher_suite.ignore"),
+		validationType:    "cipher_suite",
+		requiredLabels:    CipherSuiteLabelKeys,
+	}, nil
+}

--- a/cert-scanner/reporters/metrics/require_tls.go
+++ b/cert-scanner/reporters/metrics/require_tls.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"github.com/spf13/viper"
+)
+
+var (
+	RequireTLSLabelKeys = []string{
+		"address", "source", "source_type", "failed", "type", "target_pod", "target_namespace",
+	}
+
+	RequireTLSValidationsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "cert_scanner",
+		Name:      "require_tls_validations_total",
+		Help:      "counts the results required tls validations",
+	}, RequireTLSLabelKeys)
+)
+
+func CreateRequireTLSReporter() (Reporter, error) {
+	return &CounterReporter{
+		counter:           RequireTLSValidationsCounter,
+		ignoreResultTypes: viper.GetStringSlice("validations.require_tls.ignore"),
+		requiredLabels:    RequireTLSLabelKeys,
+		validationType:    "require_tls",
+	}, nil
+}

--- a/cert-scanner/reporters/reporters.go
+++ b/cert-scanner/reporters/reporters.go
@@ -15,6 +15,8 @@ var factories = map[string]Factory[Reporter]{
 	"tls_version":   metrics.CreateTLSVersionReporter,
 	"trust_chain":   metrics.CreateTrustChainReporter,
 	"scan_stats":    metrics.CreateScanStatsReporter,
+	"require_tls":    metrics.CreateRequireTLSReporter,
+	"cipher_suite":   metrics.CreateCipherSuiteReporter,
 }
 
 func CreateReporters() (Reporters, error) {

--- a/cert-scanner/validations/cipher_suite.go
+++ b/cert-scanner/validations/cipher_suite.go
@@ -1,0 +1,69 @@
+package validations
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"golang.org/x/exp/slog"
+)
+
+type CipherSuiteValidation struct {
+	allowedCiphers map[string]*tls.CipherSuite
+}
+
+type CipherSuiteValidationError struct {
+	ScanError
+	result *ScanResult
+}
+
+func (e *CipherSuiteValidationError) Error() string {
+	return fmt.Sprintf("negotiated cipher that was not in the configured allowed list of ciphers")
+}
+
+func (e *CipherSuiteValidationError) Labels() map[string]string {
+	labels := e.result.Labels()
+	labels["type"] = "require_tls"
+	return labels
+}
+
+func (e *CipherSuiteValidationError) Result() *ScanResult {
+	return e.result
+}
+
+func CreateCipherSuiteValidation(allowedCiphersList []string) (*CipherSuiteValidation, error) {
+
+	validCiphers := make(map[string]*tls.CipherSuite, 0)
+	allowedCiphers := make(map[string]*tls.CipherSuite, 0)
+	for _, cipher := range tls.CipherSuites() {
+		validCiphers[cipher.Name] = cipher
+	}
+
+	for _, cipher := range allowedCiphersList {
+		if allowedCipher, ok := validCiphers[cipher]; ok {
+			allowedCiphers[cipher] = allowedCipher
+		} else {
+			return nil, fmt.Errorf("configured cipher %s not present in available tls.CipherSuite", cipher)
+		}
+	}
+
+	if len(allowedCiphers) == 0 {
+		return nil, fmt.Errorf("no allowed ciphers configured, check config for validations.cipher_suite.allowed_ciphers. Ensure that at least one of the configured ciphers is present in tls.CipherSuites")
+	}
+
+	return &CipherSuiteValidation{
+		allowedCiphers: allowedCiphers,
+	}, nil
+}
+
+// Validate will examine each scan result and raise a violation any ciphers were negotiated
+// that are not on the configured allowed list.
+func (v *CipherSuiteValidation) Validate(scan *TargetScan) ScanError {
+	slog.Debug("validating target is using allowed ciphers", "target", scan.Target.Name)
+	for _, result := range scan.Results {
+		if _, allowed := v.allowedCiphers[result.Cipher.Name]; !allowed {
+			return &CipherSuiteValidationError{result: result}
+		}
+	}
+	return nil
+}

--- a/cert-scanner/validations/cipher_suite_test.go
+++ b/cert-scanner/validations/cipher_suite_test.go
@@ -1,0 +1,158 @@
+package validations
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/sgargan/cert-scanner-darkly/testutils"
+	. "github.com/sgargan/cert-scanner-darkly/testutils"
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type CipherSuiteValidationTests struct {
+	suite.Suite
+	scan           *TargetScan
+	allowedCiphers []string
+	allCiphers     []*tls.CipherSuite
+}
+
+func (t *CipherSuiteValidationTests) SetupTest() {
+	t.allCiphers = tls.CipherSuites()
+	// Use the first two ciphers as the allowed list
+	t.allowedCiphers = []string{
+		t.allCiphers[0].Name,
+		t.allCiphers[1].Name,
+	}
+
+	cert := testutils.CreateTestCert()
+	t.scan = CreateTestTargetScan().
+		WithCertificates(&cert.Certificate).
+		WithTarget(testutils.TestTarget()).
+		Build()
+}
+
+func (t *CipherSuiteValidationTests) TestCipherIsAllowed() {
+	validation, err := CreateCipherSuiteValidation(t.allowedCiphers)
+	t.NoError(err)
+
+	t.scan.Results[0].Cipher = t.allCiphers[0]
+	t.NoError(validation.Validate(t.scan))
+
+	t.scan.Results[0].Cipher = t.allCiphers[1]
+	t.NoError(validation.Validate(t.scan))
+}
+
+func (t *CipherSuiteValidationTests) TestCipherNotAllowed() {
+	validation, err := CreateCipherSuiteValidation(t.allowedCiphers)
+	t.NoError(err)
+
+	disallowedCipher := t.allCiphers[len(t.allCiphers)-1]
+	t.scan.Results[0].Cipher = disallowedCipher
+
+	err = validation.Validate(t.scan)
+	t.Error(err)
+	t.Contains(err.Error(), "negotiated cipher that was not in the configured allowed list of ciphers")
+}
+
+func (t *CipherSuiteValidationTests) TestLabelsOnViolation() {
+	validation, err := CreateCipherSuiteValidation(t.allowedCiphers)
+	t.NoError(err)
+
+	disallowedCipher := t.allCiphers[len(t.allCiphers)-1]
+	t.scan.Results[0].Cipher = disallowedCipher
+
+	violation := validation.Validate(t.scan)
+	t.Error(violation)
+
+	labels := violation.Labels()
+	t.Equal("require_tls", labels["type"])
+	t.Equal("172.1.2.34:8080", labels["address"])
+}
+
+func (t *CipherSuiteValidationTests) TestEmptyAllowedCiphersList() {
+	_, err := CreateCipherSuiteValidation([]string{})
+	t.Error(err)
+	t.Contains(err.Error(), "no allowed ciphers configured")
+}
+
+func (t *CipherSuiteValidationTests) TestInvalidCipherName() {
+	_, err := CreateCipherSuiteValidation([]string{"INVALID_CIPHER_NAME"})
+	t.Error(err)
+	t.Contains(err.Error(), "configured cipher INVALID_CIPHER_NAME not present in available tls.CipherSuite")
+}
+
+func (t *CipherSuiteValidationTests) TestMixedValidAndInvalidCiphers() {
+	_, err := CreateCipherSuiteValidation([]string{t.allCiphers[0].Name, "INVALID_CIPHER"})
+	t.Error(err)
+	t.Contains(err.Error(), "configured cipher INVALID_CIPHER not present in available tls.CipherSuite")
+}
+
+func (t *CipherSuiteValidationTests) TestMultipleResults() {
+	validation, err := CreateCipherSuiteValidation(t.allowedCiphers)
+	t.NoError(err)
+
+	cert := testutils.CreateTestCert()
+
+	result1 := NewScanResult()
+	result1.Cipher = t.allCiphers[0]
+	result1.SetState(&tls.ConnectionState{}, result1.Cipher, nil)
+
+	result2 := NewScanResult()
+	result2.Cipher = t.allCiphers[len(t.allCiphers)-1]
+	result2.SetState(&tls.ConnectionState{}, result2.Cipher, nil)
+
+	scan := CreateTestTargetScan().
+		WithCertificates(&cert.Certificate).
+		WithTarget(testutils.TestTarget()).
+		Build()
+
+	scan.Results = []*ScanResult{result1, result2}
+
+	err = validation.Validate(scan)
+	t.Error(err)
+	t.Contains(err.Error(), "negotiated cipher that was not in the configured allowed list of ciphers")
+}
+
+func (t *CipherSuiteValidationTests) TestAllResultsAllowed() {
+	validation, err := CreateCipherSuiteValidation(t.allowedCiphers)
+	t.NoError(err)
+
+	cert := testutils.CreateTestCert()
+
+	result1 := NewScanResult()
+	result1.Cipher = t.allCiphers[0]
+	result1.SetState(&tls.ConnectionState{}, result1.Cipher, nil)
+
+	result2 := NewScanResult()
+	result2.Cipher = t.allCiphers[1]
+	result2.SetState(&tls.ConnectionState{}, result2.Cipher, nil)
+
+	scan := CreateTestTargetScan().
+		WithCertificates(&cert.Certificate).
+		WithTarget(testutils.TestTarget()).
+		Build()
+
+	scan.Results = []*ScanResult{result1, result2}
+
+	t.NoError(validation.Validate(scan))
+}
+
+func (t *CipherSuiteValidationTests) TestNilResults() {
+	validation, err := CreateCipherSuiteValidation(t.allowedCiphers)
+	t.NoError(err)
+
+	// Create a scan with nil results
+	scan := NewTargetScanResult(testutils.TestTarget())
+	scan.Results = nil
+
+	// Should not panic and pass without error
+	t.NotPanics(func() {
+		err := validation.Validate(scan)
+		t.NoError(err)
+	})
+}
+
+func TestCipherSuiteValidations(t *testing.T) {
+	suite.Run(t, &CipherSuiteValidationTests{})
+}

--- a/cert-scanner/validations/require_tls.go
+++ b/cert-scanner/validations/require_tls.go
@@ -1,0 +1,49 @@
+package validations
+
+import (
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"golang.org/x/exp/slog"
+)
+
+type RequireTLSValidation struct {
+}
+
+type RequireTLSValidationError struct {
+	ScanError
+	result *ScanResult
+}
+
+func CreateRequireTLSValidation() *RequireTLSValidation {
+	return &RequireTLSValidation{}
+}
+
+func (e *RequireTLSValidationError) Error() string {
+	return "Target is not configured with TLS"
+}
+
+func (e *RequireTLSValidationError) Labels() map[string]string {
+	if e.result == nil {
+		return map[string]string{"type": "require_tls"}
+	}
+	labels := e.result.Labels()
+	labels["type"] = "require_tls"
+	return labels
+}
+
+// Validate will examine each scan result and raise a violation if no TLS was discovered for the target
+func (v *RequireTLSValidation) Validate(scan *TargetScan) ScanError {
+	slog.Debug("validating target is configured with TLS", "target", scan.Target.Name)
+
+	var lastFailed *ScanResult
+	for _, result := range scan.Results {
+		if !result.Failed {
+			// any successful result is a pass
+			return nil
+		}
+		lastFailed = result
+	}
+
+	return &RequireTLSValidationError{
+		result: lastFailed,
+	}
+}

--- a/cert-scanner/validations/require_tls_test.go
+++ b/cert-scanner/validations/require_tls_test.go
@@ -1,0 +1,41 @@
+package validations
+
+import (
+	"testing"
+
+	"github.com/sgargan/cert-scanner-darkly/testutils"
+	. "github.com/sgargan/cert-scanner-darkly/testutils"
+	. "github.com/sgargan/cert-scanner-darkly/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type RequireTLSValidationTests struct {
+	suite.Suite
+	scan *TargetScan
+}
+
+func (t *RequireTLSValidationTests) SetupTest() {
+	cert := testutils.CreateTestCert()
+	t.scan = CreateTestTargetScan().WithCertificates(&cert.Certificate).WithTarget(testutils.TestTarget()).Build()
+}
+
+func (t *RequireTLSValidationTests) TestTLSConfigured() {
+	// A successful scan (with TLS) should pass validation
+	result := CreateTestTargetScan().Build()
+	t.NoError(CreateRequireTLSValidation().Validate(result))
+}
+
+func (t *RequireTLSValidationTests) TestTLSNotConfigured() {
+	t.scan.Results[0].Failed = true
+	err := CreateRequireTLSValidation().Validate(t.scan)
+	t.Error(err)
+	t.Contains(err.Error(), "Target is not configured with TLS")
+
+	labels := err.Labels()
+	t.Equal("require_tls", labels["type"])
+	t.Equal("172.1.2.34:8080", labels["address"])
+}
+
+func TestRequireTLSValidations(t *testing.T) {
+	suite.Run(t, &RequireTLSValidationTests{})
+}

--- a/cert-scanner/validations/validations.go
+++ b/cert-scanner/validations/validations.go
@@ -19,6 +19,8 @@ var factories = map[string]Factory[Validation]{
 	"not_yet_valid": beforeValidation,
 	"tls_version":   tlsVersionValidation,
 	"trust_chain":   trustChainValidation,
+	"require_tls":   requireTLSValidation,
+	"cipher_suite":  cipherSuiteValidation,
 }
 
 func CreateValidations() (Validations, error) {
@@ -49,4 +51,13 @@ func trustChainValidation() (Validation, error) {
 
 func tlsVersionValidation() (Validation, error) {
 	return CreateTLSVersionValidation(viper.GetString(config.ValidationsTLSMinVersion))
+}
+
+func requireTLSValidation() (Validation, error) {
+	return CreateRequireTLSValidation(), nil
+}
+
+func cipherSuiteValidation() (Validation, error) {
+	allowedCiphers := viper.GetStringSlice(config.ValidationsCipherSuite)
+	return CreateCipherSuiteValidation(allowedCiphers)
 }

--- a/charts/cert-scanner/values.yaml
+++ b/charts/cert-scanner/values.yaml
@@ -23,10 +23,7 @@ scanConfig:
       ignore_pods:
         - pattern: "{.metadata.namespace}"
           match:
-            - (kube|qualtrics)-system
-            - engvis.*
-            - cilium.*
-            - log-collection
+            - some-namespace
       ignore_containers:
         - pattern: "{.spec.containers[*].ports[*].name}"
           match:
@@ -49,6 +46,11 @@ scanConfig:
       #   - /a/ca/path
       #   - /b/ca/path
       #   - /c/ca/path
+    require_tls:
+      enabled: true
+    # cipher_suite:
+    #   allowed_ciphers:
+    #     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 
   reporters:
     logging:
@@ -79,8 +81,15 @@ hosts:
 
 # use the volumes and mounts to mount any CA bundles your systems use into the scanner
 volumes: {}
-
 volumeMounts: {}
+
+# enable monitoring for the scanner
+monitor:
+  enabled: true
+  alerts:
+    require_tls: true
+    cipher_suite: true
+
 
 image:
   url: docker.io/stevegargan/cert-scanner-darkly

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1,45 +1,24 @@
 kube-prometheus-stack:
   prometheus:
     prometheusSpec:
+      ruleSelector:
+        matchLabels:
+          prometheus.io/monitor: security
       podMonitorSelector:
         matchLabels:
           prometheus.io/monitor: security
-
-  # server:
-  #   enabled: true
-  #   name: scan-test-cluster
-
-  #   persistentVolume:
-  #     enabled: false
-
-  #   emptyDir:
-  #     sizeLimit: 1G
-
-  #   alertmanagers: []
-
-  #   replicaCount: 1
-
-  #   resources:
-  #     limits:
-  #       cpu: 500m
-  #       memory: 512Mi
-  #     requests:
-  #       cpu: 500m
-  #       memory: 512Mi
-
-  #   statefulSet:
-  #     enabled: false
 
   alertmanager:
     enabled: true
 
   kube-state-metrics:
+    enabled: false
     prometheus:
       monitor:
         enabled: false
 
   nodeExporter:
-    enabled: true
+    enabled: false
 
   prometheus-node-exporter:
     prometheus:

--- a/go.work.sum
+++ b/go.work.sum
@@ -104,6 +104,7 @@ go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
 golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 create_ns() {
-    kubectl get ns $1 2&>1 > /dev/null
+    kubectl get ns $1 2>&1 > /dev/null
     if [[ $? != 0 ]]; then
       kubectl create ns $1
     fi
 }
 
 kind get clusters | grep cert-scanner > /dev/null || kind create cluster --name cert-scanner
+kubectl config use-context kind-cert-scanner
 create_ns monitoring
 create_ns security-scanners
 
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm upgrade --install prometheus charts/prometheus --namespace monitoring --values charts/prometheus/values.yaml


### PR DESCRIPTION
Adds two more validations. The first `require_tls` checks that a tls connection was successfully established to each target. The second `cipher_suite` verifies that each tls connection was established using cipher from a configured allow_list of ciphers.