### PR TITLE
fix data race on hasConnectionError in TLS processor and add -race to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install-tparse:
 	@{ [ -x ${GOPATH}/bin/tparse ] || go install github.com/mfridman/tparse@latest ;}
 
 test: install-tparse
-	cd cert-scanner && go test ./... -json -v -p 1 -count=1 -coverprofile=coverage.out | tparse -follow -all
+	cd cert-scanner && go test -race ./... -json -v -p 1 -count=1 -coverprofile=coverage.out | tparse -follow -all
 
 cover: test
 	go tool cover -html=coverage.out

--- a/cert-scanner/processors/tls_state_retrieval.go
+++ b/cert-scanner/processors/tls_state_retrieval.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/exp/slog"
@@ -34,7 +35,7 @@ func (c *TLSStateRetrieval) Process(ctx context.Context, target *Target, results
 	wait := &utils.ContextualWaitGroup{}
 	targetScan := NewTargetScanResult(target)
 
-	hasConnectionError := false
+	var hasConnectionError atomic.Bool
 	for _, x := range orderedCipherSuites {
 		cipher := x
 		wait.Add(len(cipher.SupportedVersions))
@@ -45,14 +46,16 @@ func (c *TLSStateRetrieval) Process(ctx context.Context, target *Target, results
 				result := NewScanResult()
 				state, err := c.makeConnectionWithConfig(ctx, result, target, getConfig(target, cipher.ID, version))
 				result.SetState(state, cipher, err)
-				hasConnectionError = hasConnectionError || IsError(err, ConnectionError)
+				if IsError(err, ConnectionError) {
+					hasConnectionError.Store(true)
+				}
 				targetScan.Add(result)
 			}()
 		}
 	}
 	wait.WaitWithContext(ctx)
 
-	if hasConnectionError {
+	if hasConnectionError.Load() {
 		slog.Error("error making connection to target", "address", target.Address.String())
 	}
 	results <- targetScan

--- a/cert-scanner/utils/batch_test.go
+++ b/cert-scanner/utils/batch_test.go
@@ -57,24 +57,24 @@ func (t *BatchProcessTests) TestProcessesInBatches() {
 }
 
 func (t *BatchProcessTests) TestSliceRequired() {
-	called := false
+	var called atomic.Bool
 	group := BatchProcess[*Item](context.Background(), nil, 10, func(ctx context.Context, item *Item) (err error) {
-		called = true
+		called.Store(true)
 		return nil
 	})
 	err := group.Wait()
-	t.False(called)
+	t.False(called.Load())
 	t.ErrorContains(err, "a valid slice of items to process is required")
 }
 
 func (t *BatchProcessTests) TestUsesItemsLengthIfLargerBatchSizeRequested() {
-	called := false
+	var called atomic.Bool
 	group := BatchProcess[int](context.Background(), []int{1, 2, 3}, 10, func(ctx context.Context, item int) (err error) {
-		called = true
+		called.Store(true)
 		return nil
 	})
 	t.NoError(group.Wait())
-	t.True(called)
+	t.True(called.Load())
 }
 
 func TestBatchProcessTests(t *testing.T) {


### PR DESCRIPTION
Multiple goroutines in Process() were reading and writing hasConnectionError without synchronization. Replaced with sync/atomic.Bool. Added -race to the test target so the race detector runs on every CI build going forward.