### PR TITLE
replace uncatchable SIGKILL with SIGTERM and stop leaking cancel functions

### DIFF
--- a/cert-scanner/cmd/scanner.go
+++ b/cert-scanner/cmd/scanner.go
@@ -60,7 +60,8 @@ func Run(cmd *cobra.Command, args []string) {
 }
 
 func repeatedly() {
-	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGKILL)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
 	interval := viper.GetDuration(config.Interval)
 	ticker := time.NewTicker(interval)
 	running := false
@@ -102,7 +103,9 @@ func once() {
 func scan(ctx context.Context) (*scanner.Scan, error) {
 	timeout := viper.GetDuration(config.Timeout)
 	if timeout != 0 {
-		ctx, _ = utils.CreateSignalledContextWithContext(ctx, timeout, syscall.SIGKILL)
+		var cancel context.CancelFunc
+		ctx, cancel = utils.CreateSignalledContextWithContext(ctx, timeout, syscall.SIGTERM)
+		defer cancel()
 	}
 	return scanner.PerformScan(ctx)
 }

--- a/cert-scanner/utils/cancel.go
+++ b/cert-scanner/utils/cancel.go
@@ -15,8 +15,12 @@ func CreateSignalledContext(timeout time.Duration, signals ...os.Signal) (contex
 
 // Create a Context to enrich the given context such that it will be cancelled if any of the given Signals are received or if the given timeout elapses.
 func CreateSignalledContextWithContext(ctx context.Context, timeout time.Duration, signals ...os.Signal) (context.Context, context.CancelFunc) {
-	withSignals, _ := signal.NotifyContext(ctx, signals...)
-	return context.WithTimeout(withSignals, timeout)
+	withSignals, stopSignals := signal.NotifyContext(ctx, signals...)
+	timeoutCtx, cancel := context.WithTimeout(withSignals, timeout)
+	return timeoutCtx, func() {
+		cancel()
+		stopSignals()
+	}
 }
 
 type ContextualWaitGroup struct {

--- a/cert-scanner/utils/cancel_test.go
+++ b/cert-scanner/utils/cancel_test.go
@@ -51,6 +51,12 @@ func (t *CancelContextTests) TestWaitWithContextReleasedWhenContexCancelled() {
 	t.True(done.Load())
 }
 
+func (t *CancelContextTests) TestCancelFunctionCancelsContext() {
+	ctx, cancel := CreateSignalledContext(10*time.Second, syscall.SIGUSR1)
+	cancel()
+	t.NotNil(ctx.Err())
+}
+
 func (t *CancelContextTests) TestWaitWithContextReleasedWhenWaitDone() {
 	ctx := context.Background()
 	wwc := &ContextualWaitGroup{}


### PR DESCRIPTION
SIGKILL cannot be intercepted by the Go runtime so all graceful shutdown paths were silently broken. Replaced with SIGTERM throughout. Also fixed CreateSignalledContextWithContext to return a combined cancel that stops both the timeout and the signal handler goroutine, and captured the returned cancels at each call site with defer.