### PR TITLE
fix issue scanning expired cert in canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ local-dev: KO_DOCKER_REPO=ko.local
 local-dev:
 	ko build github.com/sgargan/cert-scanner-darkly --tags $(VERSION) --base-import-paths -L
 	$(eval IMAGE:=$(KO_DOCKER_REPO)/cert-scanner-darkly:$(VERSION))
-	kind load docker-image --name vsm $(IMAGE)
+	kind load docker-image --name cert-scanner $(IMAGE)
 	$(call deploy)
 
 local-canary: VERSION=dev
@@ -75,6 +75,6 @@ deploy:
 define deploy
 	$(eval URL:=$(KO_DOCKER_REPO)/cert-scanner-darkly)
 	{ kubectl create namespace ${NAMESPACE} || true ;}
-	helm upgrade --install -n ${NAMESPACE} $(CHART) charts/$(CHART) --values charts/cert-scanner/values.yaml --set image.url=$(URL) --set image.tag=$(VERSION) --set image.pullPolicy=Never
+	helm upgrade --install -n ${NAMESPACE} $(CHART) charts/$(CHART) --values charts/$(CHART)/values.yaml --set image.url=$(URL) --set image.tag=$(VERSION) --set image.pullPolicy=Never
 	kubectl rollout restart deployment -n ${NAMESPACE} $(CHART)
 endef

--- a/cert-scanner/discovery/kubernetes/discover_test.go
+++ b/cert-scanner/discovery/kubernetes/discover_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/sgargan/cert-scanner-darkly/config"
@@ -37,9 +36,9 @@ func (t *DiscoveryTests) TestDiscoveryLoadsConfig() {
 	t.Equal([]string{"foo", "bar"}, discovery.labelKeys)
 	t.Len(discovery.ignorePatterns, 2)
 	t.Equal("{.metadata.name}", discovery.ignorePatterns[0].pattern)
-	t.Equal(regexp.MustCompile("some-pod"), discovery.ignorePatterns[0].matches[0])
+	t.Equal("some-pod", discovery.ignorePatterns[0].matches[0].String())
 	t.Equal("{.metadata.name}", discovery.ignorePatterns[1].pattern)
-	t.Equal(regexp.MustCompile("cert-scanner"), discovery.ignorePatterns[1].matches[0])
+	t.Equal(`^cert-scanner-(?!canary).*$`, discovery.ignorePatterns[1].matches[0].String())
 }
 
 func TestDiscoveryTests(t *testing.T) {

--- a/cert-scanner/discovery/kubernetes/pods.go
+++ b/cert-scanner/discovery/kubernetes/pods.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"regexp"
+
 	"strings"
 
+	"github.com/dlclark/regexp2"
 	. "github.com/sgargan/cert-scanner-darkly/types"
 	"golang.org/x/exp/slog"
 
@@ -40,7 +41,7 @@ type PodDiscovery struct {
 type parsedIgnorePattern struct {
 	pattern  string
 	jsonPath *jsonpath.JSONPath
-	matches  []*regexp.Regexp
+	matches  []*regexp2.Regexp
 }
 
 type IgnorePattern struct {
@@ -68,7 +69,8 @@ func CreatePodDiscovery(config PodDiscoveryConfig, pods PodsInterface) (*PodDisc
 		return nil, fmt.Errorf("no pods api has been provided")
 	}
 
-	config.ignorePatterns = append(config.ignorePatterns, IgnorePattern{Pattern: "{.metadata.name}", Match: []string{"cert-scanner"}})
+	config.ignorePatterns = append(config.ignorePatterns, IgnorePattern{Pattern: "{.metadata.name}",
+		Match: []string{`^cert-scanner-(?!canary).*$`}})
 	ignorePodPatterns, err := parseIgnorePatterns(config.ignorePatterns)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing ignore patterns: %v", err)
@@ -218,7 +220,7 @@ func ignore(pod *v1.Pod, patterns []parsedIgnorePattern) (bool, error) {
 
 				// Check if extracted value matches any of the specified match values
 				for _, matchValue := range pattern.matches {
-					if matchValue.MatchString(extractedValue) {
+					if matches, err := matchValue.MatchString(extractedValue); matches && err == nil {
 						slog.Debug("ignoring due to pattern match", "pod", pod.Name, "pattern", pattern.pattern, "value", extractedValue)
 						return true, nil
 					}
@@ -255,9 +257,9 @@ func parseIgnorePatterns(ignorePatterns []IgnorePattern) ([]parsedIgnorePattern,
 		if err != nil {
 			return nil, err
 		}
-		matches := make([]*regexp.Regexp, 0, len(pattern.Match))
+		matches := make([]*regexp2.Regexp, 0, len(pattern.Match))
 		for _, match := range pattern.Match {
-			matches = append(matches, regexp.MustCompile(match))
+			matches = append(matches, regexp2.MustCompile(match, regexp2.None))
 		}
 		parsedPatterns = append(parsedPatterns, parsedIgnorePattern{
 			pattern:  pattern.Pattern,

--- a/cert-scanner/discovery/kubernetes/pods_test.go
+++ b/cert-scanner/discovery/kubernetes/pods_test.go
@@ -220,16 +220,20 @@ func (t *PodTests) TestIgnoresPodsWithUnreadyContainers() {
 	t.Equal(0, len(targets))
 }
 
-func (t *PodTests) TestIgnoresScanner() {
+func (t *PodTests) TestIgnoresScannerButNotCanary() {
 	os.Setenv(ScannerPodEnvName, "cert-scanner-12345fed")
 	t.AddPods("cert-scanner-1234abcd", "some-namespace", map[string]string{},
 		v1.PodIP{IP: "10.0.1.1"}, createContainerPort(8080),
 	)
 
+	t.AddPods("cert-scanner-canary-1234abcd", "some-namespace", map[string]string{},
+		v1.PodIP{IP: "10.0.1.2"}, createContainerPort(8080),
+	)
+
 	podDiscovery, _ := CreatePodDiscovery(t.config, t.Build())
 	targets := make(chan *Target, 2)
 	t.NoError(podDiscovery.Discover(context.Background(), targets))
-	t.Equal(0, len(targets))
+	t.Equal(1, len(targets))
 }
 
 func createContainerPort(port int32) v1.ContainerPort {

--- a/cert-scanner/go.mod
+++ b/cert-scanner/go.mod
@@ -1,6 +1,7 @@
 module github.com/sgargan/cert-scanner-darkly
 
 require (
+	github.com/dlclark/regexp2 v1.12.0
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/spf13/cobra v1.9.1

--- a/cert-scanner/go.sum
+++ b/cert-scanner/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/cert-scanner/processors/tls_state_retrieval.go
+++ b/cert-scanner/processors/tls_state_retrieval.go
@@ -88,15 +88,14 @@ func (c *TLSStateRetrieval) makeConnectionWithConfig(ctx context.Context, result
 
 func getConfig(target *Target, cipher, version uint16) *tls.Config {
 	config := &tls.Config{
-		CipherSuites: []uint16{cipher},
-		MaxVersion:   version,
-		MinVersion:   version,
+		CipherSuites:       []uint16{cipher},
+		MaxVersion:         version,
+		MinVersion:         version,
+		InsecureSkipVerify: true,
 	}
 
 	if target.Address.ValidateHostname() {
 		config.ServerName = target.Address.String()
-	} else {
-		config.InsecureSkipVerify = true
 	}
 	return config
 }

--- a/cert-scanner/processors/tls_state_retrieval_test.go
+++ b/cert-scanner/processors/tls_state_retrieval_test.go
@@ -60,6 +60,43 @@ func (t *CertScannerTests) TestConnectionError() {
 	t.ValidateError(results[0], ConnectionError)
 }
 
+func (t *CertScannerTests) TestScanExpiredCert() {
+	const port = 33335
+	target := &Target{
+		Address: getAddress(fmt.Sprintf("127.0.0.1:%d", port)),
+	}
+	err := testutils.WithTestServerFromConfig(expiredCertTLSConfig(tls.VersionTLS12), port, func(_ *testutils.TestTlsServer) error {
+		scans := t.runScan(target)
+		t.Require().Len(scans, 1)
+		scan := scans[0]
+		t.Require().NotNil(scan.FirstSuccessful)
+		r := scan.FirstSuccessful
+		t.NotNil(r.State)
+		t.Require().Len(r.State.PeerCertificates, 1)
+		t.True(r.State.PeerCertificates[0].NotAfter.Before(time.Now()))
+		return nil
+	})
+	t.NoError(err)
+}
+
+func expiredCertTLSConfig(tlsVersion uint16) *tls.Config {
+	ca, err := testutils.CreateTestCA(0)
+	if err != nil {
+		panic(err)
+	}
+	serialNumber, err := testutils.CreateSerialNumber()
+	if err != nil {
+		panic(err)
+	}
+	template := testutils.CreateLeafTemplate("localhost", serialNumber)
+	template.NotAfter = time.Now().Add(-24 * time.Hour)
+	_, certPem, key, err := ca.CreateLeafFromTemplate(template)
+	if err != nil {
+		panic(err)
+	}
+	return testutils.CreateTestTLSConfig(tlsVersion, certPem, key)
+}
+
 func (t *CertScannerTests) TestHandshakeError() {
 	go func() {
 		http.ListenAndServe("127.0.0.1:33334", nil)

--- a/cert-scanner/testutils/canary/canary.go
+++ b/cert-scanner/testutils/canary/canary.go
@@ -20,13 +20,14 @@ func RunCanary(port int) {
 
 	// setup the cert to expire iminently
 	template := testutils.CreateLeafTemplate("some-server", serial)
-	template.NotAfter = time.Now()
+	template.NotAfter = time.Now().Add(-1 * time.Hour)
 
 	_, certPem, key, err := ca.CreateLeafFromTemplate(template)
 	failOnError("error creating certificate for server", err)
 
-	// create server with 1.1 config
+	// create server with 1.1 config to trigger tls_version violations
 	config := testutils.CreateTestTLSConfig(tls.VersionTLS11, certPem, key)
+	config.MaxVersion = tls.VersionTLS11
 	testutils.NewTestTlsServerWithHandler(config, port, handler)
 
 	fmt.Printf("Running canary on :%d\n", port)

--- a/cert-scanner/testutils/server.go
+++ b/cert-scanner/testutils/server.go
@@ -25,7 +25,7 @@ func NewTestTlsServer(config *tls.Config, port int) *TestTlsServer {
 }
 
 func NewTestTlsServerWithHandler(config *tls.Config, port int, handler http.HandlerFunc) *TestTlsServer {
-	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
 		panic(err)
 	}

--- a/cert-scanner/types/types.go
+++ b/cert-scanner/types/types.go
@@ -74,7 +74,7 @@ func (n *UrlAddress) Connect(ctx context.Context) (net.Conn, error) {
 	if port == "" && (n.url.Scheme == "tls" || n.url.Scheme == "https") {
 		port = "443"
 	}
-	return dialer.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", n.url.Host, port))
+	return dialer.DialContext(ctx, "tcp", net.JoinHostPort(n.url.Hostname(), port))
 }
 
 // URLs shoud validate the hostname as part of the tls handshake
@@ -140,6 +140,22 @@ func (t *TargetScan) Failed() bool {
 		}
 	}
 	return false
+}
+
+func (t *TargetScan) ResultWithCertificates() *ScanResult {
+	if hasPeerCertificates(t.FirstSuccessful) {
+		return t.FirstSuccessful
+	}
+	for _, result := range t.Results {
+		if hasPeerCertificates(result) {
+			return result
+		}
+	}
+	return nil
+}
+
+func hasPeerCertificates(result *ScanResult) bool {
+	return result != nil && result.State != nil && len(result.State.PeerCertificates) > 0
 }
 
 // AddViolation adds a detected violation for one ScanResult to the target scan

--- a/cert-scanner/validations/expired.go
+++ b/cert-scanner/validations/expired.go
@@ -31,6 +31,9 @@ func (e *ExpiryValidationError) Result() *ScanResult {
 }
 
 func (e *ExpiryValidationError) Error() string {
+	if time.Now().After(e.notAfter) {
+		return fmt.Sprintf("cert expired on %s", e.notAfter.Format(time.RFC822))
+	}
 	return fmt.Sprintf("cert will expire in less than %s on %s", e.warningDuration.String(), e.notAfter.Format(time.RFC822))
 }
 
@@ -50,17 +53,28 @@ func CreateExpiryValidation(warningDuration time.Duration) *ExpiryValidation {
 }
 
 // Validate will examine the cert from the first successful ScanResult in a TargetScan
-// and check that it's not within the configured time warning window before expiry. If the cert
-// expiry falls in the the warning window, this validation will fail and raise a validation error
+// and check that it is not already expired and not within the configured warning window
+// before expiry. If either condition is met, this validation will fail.
 func (v *ExpiryValidation) Validate(scan *TargetScan) ScanError {
 	slog.Debug("validating cert of target will not expire soon", "target", scan.Target.Name, "warning_duration", v.warningDuration.String())
-	if !scan.Failed() {
-		result := scan.FirstSuccessful
-		for _, cert := range result.State.PeerCertificates {
-			if time.Until(cert.NotAfter) < v.warningDuration {
-				return CreateExpiryValidationError(v.warningDuration, cert.NotAfter, result)
-			}
+	result := scan.ResultWithCertificates()
+	if result == nil {
+		slog.Debug("no peer certificates found in scan result", "target", scan.Target.Name)
+		return nil
+	}
+
+	now := time.Now()
+	for _, cert := range result.State.PeerCertificates {
+		if certExpiredOrExpiringSoon(now, cert.NotAfter, v.warningDuration) {
+			return CreateExpiryValidationError(v.warningDuration, cert.NotAfter, result)
 		}
 	}
 	return nil
+}
+
+func certExpiredOrExpiringSoon(now, notAfter time.Time, warningDuration time.Duration) bool {
+	if now.After(notAfter) {
+		return true
+	}
+	return notAfter.Sub(now) < warningDuration
 }

--- a/cert-scanner/validations/expired_test.go
+++ b/cert-scanner/validations/expired_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sgargan/cert-scanner-darkly/testutils"
 	. "github.com/sgargan/cert-scanner-darkly/testutils"
+	. "github.com/sgargan/cert-scanner-darkly/types"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -34,6 +35,34 @@ func (t *ExpiryValidationTests) TestWillExpireInNDays() {
 	result := CreateTestTargetScan().WithCertificates(&cert.Certificate).Build()
 	t.ErrorContains(CreateExpiryValidation(7*day).Validate(result), "cert will expire in less than 168h0m0s on ")
 }
+
+func (t *ExpiryValidationTests) TestAlreadyExpired() {
+	cert := CreateTestCert().WithAfter(time.Now().Add(-1 * day))
+	result := CreateTestTargetScan().WithCertificates(&cert.Certificate).Build()
+	t.ErrorContains(CreateExpiryValidation(7*day).Validate(result), "cert expired on ")
+}
+
+func (t *ExpiryValidationTests) TestAlreadyExpiredFromFailedConnection() {
+	cert := CreateTestCert().WithAfter(time.Now().Add(-1 * day))
+	scan := CreateTestTargetScan().WithCertificates(&cert.Certificate).WithError(&testScanError{}).Build()
+	scan.FirstSuccessful = nil
+	t.Nil(scan.FirstSuccessful)
+	t.NotNil(scan.ResultWithCertificates())
+	t.ErrorContains(CreateExpiryValidation(7*day).Validate(scan), "cert expired on ")
+}
+
+func (t *ExpiryValidationTests) TestCertExpiredOrExpiringSoon() {
+	now := time.Now()
+	t.True(certExpiredOrExpiringSoon(now, now.Add(-24*time.Hour), 7*day))
+	t.True(certExpiredOrExpiringSoon(now, now.Add(24*time.Hour), 7*day))
+	t.False(certExpiredOrExpiringSoon(now, now.Add(8*day), 7*day))
+}
+
+type testScanError struct{}
+
+func (e *testScanError) Error() string   { return "scan failed" }
+func (e *testScanError) Labels() map[string]string { return map[string]string{"type": "test"} }
+func (e *testScanError) Result() *ScanResult       { return nil }
 
 func (t *ExpiryValidationTests) TestLabels() {
 	cert, _, _, err := t.ca.CreateLeafCert("somehost")

--- a/cert-scanner/validations/not_yet_valid.go
+++ b/cert-scanner/validations/not_yet_valid.go
@@ -42,17 +42,18 @@ func CreateBeforeValidation() *BeforeValidation {
 // Validate will examine each cert in a scan result raise a violation
 // if the cert will not become valid until some time in the future
 func (v *BeforeValidation) Validate(scan *TargetScan) ScanError {
-	slog.Debug("validating cert of taget is currently valid", "target", scan.Target.Name)
+	slog.Debug("validating cert of target is currently valid", "target", scan.Target.Name)
 
-	if !scan.Failed() {
-		result := scan.FirstSuccessful
-		for _, cert := range result.State.PeerCertificates {
-			untilValid := time.Until(cert.NotBefore)
-			if untilValid > 0 {
-				return &BeforeValidationError{
-					untilValid: untilValid,
-					notBefore:  cert.NotBefore,
-				}
+	result := scan.ResultWithCertificates()
+	if result == nil {
+		return nil
+	}
+	for _, cert := range result.State.PeerCertificates {
+		untilValid := time.Until(cert.NotBefore)
+		if untilValid > 0 {
+			return &BeforeValidationError{
+				untilValid: untilValid,
+				notBefore:  cert.NotBefore,
 			}
 		}
 	}

--- a/cert-scanner/validations/trust_chain.go
+++ b/cert-scanner/validations/trust_chain.go
@@ -114,12 +114,8 @@ func loadCaCertsFromPaths(rootCAs *x509.CertPool, caCertPaths []string) (int, er
 // of root CA certs ignoring any ServerNames in the certs.
 func (v *TrustChainValidation) Validate(scan *TargetScan) ScanError {
 	slog.Debug("validating trust of target", "target", scan.Target.Name)
-	if scan.Failed() {
-		return nil
-	}
-
-	result := scan.FirstSuccessful
-	if v.rootCAs == nil {
+	result := scan.ResultWithCertificates()
+	if result == nil || v.rootCAs == nil {
 		return nil
 	}
 

--- a/cert-scanner/validations/validations.go
+++ b/cert-scanner/validations/validations.go
@@ -29,13 +29,14 @@ func CreateValidations() (Validations, error) {
 
 func expiryValidation() (Validation, error) {
 	warning := DefaultWarningDuration
-	duration := viper.GetString(config.ValidationsExpiryWindow)
-	if duration != "" {
-		if parsed, err := time.ParseDuration(duration); err != nil {
+	if duration := viper.GetString(config.ValidationsExpiryWindow); duration != "" {
+		parsed, err := time.ParseDuration(duration)
+		if err != nil {
 			return nil, fmt.Errorf("error parsing expiry warning duration from %s", duration)
-		} else {
-			warning = parsed
 		}
+		warning = parsed
+	} else if duration := viper.GetDuration(config.ValidationsExpiryWindow); duration != 0 {
+		warning = duration
 	}
 	return CreateExpiryValidation(warning), nil
 }

--- a/charts/cert-scanner-canary/values.yaml
+++ b/charts/cert-scanner-canary/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 canaryConfig:
   canary:
-    port: 9253
+    port: 8080
 
 image:
   url: docker.io/stevegargan/cert-scanner-canary-darkly


### PR DESCRIPTION
The scanner was unable to successfully retrieve certificates from the canary as they're expired and the handshake doesn't succeed. Later when t goes to validate the certs for expiry there aren't any. This lead to production misses where the scanner would not detect certs that were already expired.

These changes rework the connection handling to make a best effort attempt to parse the certificates and make them available to the validations.

The canary was not deploying correctly since the addition of port based exclusions and so has been moved to run on another port.